### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint Check
+permissions:
+  contents: read
 
 on: [ pull_request_target ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/nberserk/cabinet/security/code-scanning/3](https://github.com/nberserk/cabinet/security/code-scanning/3)

To fix this problem, we need to add a `permissions` block specifying the minimal required permissions for the jobs in the workflow. Since the linting process only requires reading the repository's code (for checking it out and running the linter), the most restrictive and correct configuration is `contents: read`. This block can be added either at the root level of the workflow (so it applies to all jobs by default) or at the job level for each job that needs restricted permissions. In this case, adding it at the workflow's root is straightforward and will apply to all jobs unless otherwise overridden.

The change should be made at the top of the workflow, preferably after the workflow `name:` key and before the `on:` key (for clarity and convention).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
